### PR TITLE
Bump to version 1.0.25

### DIFF
--- a/src/tasks/create-pull-request-task/task.json
+++ b/src/tasks/create-pull-request-task/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 23
+        "Patch": 25
     },
     "instanceNameFormat": "Create pull request",
     "inputs": [{

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "github-pr-tasks",
-    "version": "1.0.23",
+    "version": "1.0.25",
     "name": "Github pull request tasks",
     "publisher": "elranu",
     "description": "Github pull request tasks for Azure Pipelines",


### PR DESCRIPTION
Related #2

I skipped 1.0.24 since it's what you deployed yesterday and I wanted to avoid potential version conflicts.
I think I updated the right files to ensure Azure DevOps picks up the updated version properly


Reference: https://stackoverflow.com/a/58788556/1349241